### PR TITLE
[TT-002] Implement Stream-aligned Team

### DIFF
--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -17,7 +17,7 @@
 !$TEAM_FONT_SIZE ?= 14
 
 ' Team Type Colors
-!$STREAM_ALIGNED_COLOR = "#FAE1A0"  ' Stream-aligned team (beige/yellow from book)
+!$STREAM_ALIGNED_COLOR = "#FAE1A0"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center

--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -17,7 +17,7 @@
 !$TEAM_FONT_SIZE ?= 14
 
 ' Team Type Colors
-!$TEAM_ALIGNED_COLOR ?= "#2196F3"    ' Stream-aligned team (blue)
+!define TEAM_ALIGNED_COLOR #2196F3    ' Stream-aligned team (blue)
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -32,8 +32,8 @@ skinparam rectangle {
 
 ' Stream-aligned Team style
 skinparam rectangle<<aligned>> {
-  BackgroundColor $TEAM_ALIGNED_COLOR
-  BorderColor $TEAM_ALIGNED_COLOR
+  BackgroundColor TEAM_ALIGNED_COLOR
+  BorderColor TEAM_ALIGNED_COLOR
   FontColor white
   RoundCorner 20
   Shadowing false
@@ -47,10 +47,10 @@ skinparam rectangle<<aligned>> {
 
 ' Stream-aligned team
 !unquoted procedure Team_Aligned($alias, $label)
-  rectangle "$label" as $alias <<aligned>> #$TEAM_ALIGNED_COLOR
+  rectangle "$label" as $alias <<aligned>>
 !endprocedure
 
 ' Stream-aligned team with description
 !unquoted procedure Team_Aligned($alias, $label, $descr)
-  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<aligned>> #$TEAM_ALIGNED_COLOR
+  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<aligned>>
 !endprocedure

--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -17,7 +17,7 @@
 !$TEAM_FONT_SIZE ?= 14
 
 ' Team Type Colors
-!define TEAM_ALIGNED_COLOR #2196F3    ' Stream-aligned team (blue)
+!$STREAM_ALIGNED_COLOR = "#2196F3"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -30,10 +30,10 @@ skinparam rectangle {
   FontSize $TEAM_FONT_SIZE
 }
 
-' Stream-aligned Team style
-skinparam rectangle<<aligned>> {
-  BackgroundColor TEAM_ALIGNED_COLOR
-  BorderColor TEAM_ALIGNED_COLOR
+' Define specific style for Stream-aligned teams
+skinparam rectangle<<stream-aligned>> {
+  BackgroundColor #2196F3
+  BorderColor #2196F3
   FontColor white
   RoundCorner 20
   Shadowing false
@@ -47,10 +47,10 @@ skinparam rectangle<<aligned>> {
 
 ' Stream-aligned team
 !unquoted procedure Team_Aligned($alias, $label)
-  rectangle "$label" as $alias <<aligned>>
+  rectangle "$label" as $alias <<stream-aligned>>
 !endprocedure
 
 ' Stream-aligned team with description
 !unquoted procedure Team_Aligned($alias, $label, $descr)
-  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<aligned>>
+  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<stream-aligned>>
 !endprocedure

--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -16,6 +16,9 @@
 !$TEAM_FONT_COLOR ?= "#333333"
 !$TEAM_FONT_SIZE ?= 14
 
+' Team Type Colors
+!$TEAM_ALIGNED_COLOR ?= "#2196F3"    ' Stream-aligned team (blue)
+
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
 
@@ -27,7 +30,27 @@ skinparam rectangle {
   FontSize $TEAM_FONT_SIZE
 }
 
+' Stream-aligned Team style
+skinparam rectangle<<aligned>> {
+  BackgroundColor $TEAM_ALIGNED_COLOR
+  BorderColor $TEAM_ALIGNED_COLOR
+  FontColor white
+  RoundCorner 20
+  Shadowing false
+  Padding 15
+}
+
 ' Basic team definition
 !unquoted procedure Team($label)
   rectangle "$label"
+!endprocedure
+
+' Stream-aligned team
+!unquoted procedure Team_Aligned($alias, $label)
+  rectangle "$label" as $alias <<aligned>> #$TEAM_ALIGNED_COLOR
+!endprocedure
+
+' Stream-aligned team with description
+!unquoted procedure Team_Aligned($alias, $label, $descr)
+  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<aligned>> #$TEAM_ALIGNED_COLOR
 !endprocedure

--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -17,7 +17,7 @@
 !$TEAM_FONT_SIZE ?= 14
 
 ' Team Type Colors
-!$STREAM_ALIGNED_COLOR = "#2196F3"
+!$STREAM_ALIGNED_COLOR = "#FAE1A0"  ' Stream-aligned team (beige/yellow from book)
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -32,9 +32,9 @@ skinparam rectangle {
 
 ' Define specific style for Stream-aligned teams
 skinparam rectangle<<stream-aligned>> {
-  BackgroundColor #2196F3
-  BorderColor #2196F3
-  FontColor white
+  BackgroundColor #FAE1A0
+  BorderColor #E8C878
+  FontColor #333333
   RoundCorner 20
   Shadowing false
   Padding 15

--- a/tests/test-stream-aligned-team.puml
+++ b/tests/test-stream-aligned-team.puml
@@ -1,0 +1,12 @@
+@startuml
+' Test diagram for TT-002: Stream-aligned Team
+
+!include ../src/team-topologies.puml
+
+' Test Stream-aligned team - Basic version
+Team_Aligned("frontend", "Frontend")
+
+' Test Stream-aligned team - With description
+Team_Aligned("mobile", "Mobile App", "Builds and maintains customer-facing apps")
+
+@enduml


### PR DESCRIPTION
Implement Stream-aligned team visual representation

This change adds the first team type from Team Topologies to the PlantUML extension. The Stream-aligned team is now properly represented with appropriate styling that matches the book's conventions.

Key improvements:
- Add Stream-aligned team color definition (#FAE1A0)
- Create two Team_Aligned macro variants:
  - Basic: alias and label only
  - Extended: includes description support
- Apply consistent styling with:
  - Beige/yellow background with darker border
  - Rounded corners (20px)
  - Proper text formatting and padding

The implementation follows PlantUML best practices with namespace isolation and unquoted procedures to ensure compatibility with other extensions.

Resolves: #TT-002