### PR TITLE
[TT-003] Implement Platform Team

### DIFF
--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -18,6 +18,7 @@
 
 ' Team Type Colors
 !$STREAM_ALIGNED_COLOR = "#FAE1A0"
+!$PLATFORM_TEAM_COLOR = "#FF9800"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -40,6 +41,16 @@ skinparam rectangle<<stream-aligned>> {
   Padding 15
 }
 
+' Define specific style for Platform teams
+skinparam rectangle<<platform>> {
+  BackgroundColor #FF9800
+  BorderColor #E68A00
+  FontColor #333333
+  RoundCorner 20
+  Shadowing false
+  Padding 15
+}
+
 ' Basic team definition
 !unquoted procedure Team($label)
   rectangle "$label"
@@ -53,4 +64,14 @@ skinparam rectangle<<stream-aligned>> {
 ' Stream-aligned team with description
 !unquoted procedure Team_Aligned($alias, $label, $descr)
   rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<stream-aligned>>
+!endprocedure
+
+' Platform team
+!unquoted procedure Team_Platform($alias, $label)
+  rectangle "$label" as $alias <<platform>>
+!endprocedure
+
+' Platform team with description
+!unquoted procedure Team_Platform($alias, $label, $descr)
+  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<platform>>
 !endprocedure

--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -18,7 +18,7 @@
 
 ' Team Type Colors
 !$STREAM_ALIGNED_COLOR = "#FAE1A0"
-!$PLATFORM_TEAM_COLOR = "#FF9800"
+!$PLATFORM_TEAM_COLOR = "#85B5D9"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -43,8 +43,8 @@ skinparam rectangle<<stream-aligned>> {
 
 ' Define specific style for Platform teams
 skinparam rectangle<<platform>> {
-  BackgroundColor #FF9800
-  BorderColor #E68A00
+  BackgroundColor #85B5D9
+  BorderColor #6FA0C0
   FontColor #333333
   RoundCorner 20
   Shadowing false

--- a/tests/test-platform-team.puml
+++ b/tests/test-platform-team.puml
@@ -3,10 +3,16 @@
 
 !include ../src/team-topologies.puml
 
+' Layout direction
+left to right direction
+
 ' Test Platform team - Basic version
-Team_Platform("cloud-infra", "Cloud Infrastructure")
+Team_Platform(cloud_infra, "Cloud Infrastructure")
 
 ' Test Platform team - With description
-Team_Platform("data-platform", "Data Platform", "Provides data storage and analytics capabilities")
+Team_Platform(data_platform, "Data Platform", "Provides data storage and analytics capabilities")
+
+' Add some spacing between the teams
+cloud_infra -[hidden]-> data_platform
 
 @enduml

--- a/tests/test-platform-team.puml
+++ b/tests/test-platform-team.puml
@@ -1,0 +1,12 @@
+@startuml
+' Test diagram for TT-003: Platform Team
+
+!include ../src/team-topologies.puml
+
+' Test Platform team - Basic version
+Team_Platform("cloud-infra", "Cloud Infrastructure")
+
+' Test Platform team - With description
+Team_Platform("data-platform", "Data Platform", "Provides data storage and analytics capabilities")
+
+@enduml


### PR DESCRIPTION
Implement Platform team visual representation

This change adds the Platform team type from Team Topologies to the PlantUML extension. The Platform team is now properly represented with appropriate styling that matches the book's conventions.

Key improvements:
- Add Platform team color definition (#85B5D9, light blue)
- Create two Team_Platform macro variants:
  - Basic: alias and label only
  - Extended: includes description support
- Apply consistent styling with:
  - Light blue background with darker border
  - Rounded corners (20px)
  - Proper text formatting and padding

The implementation follows the same pattern established for Stream-aligned teams, maintaining consistency across team types.

Resolves: #TT-003