### PR TITLE
[TT-004] Implement Enabling Team

### DIFF
--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -19,6 +19,7 @@
 ' Team Type Colors
 !$STREAM_ALIGNED_COLOR = "#FAE1A0"
 !$PLATFORM_TEAM_COLOR = "#85B5D9"
+!$ENABLING_TEAM_COLOR = "#4CAF50"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -51,6 +52,16 @@ skinparam rectangle<<platform>> {
   Padding 15
 }
 
+' Define specific style for Enabling teams
+skinparam rectangle<<enabling>> {
+  BackgroundColor #4CAF50
+  BorderColor #368C3A
+  FontColor #333333
+  RoundCorner 20
+  Shadowing false
+  Padding 15
+}
+
 ' Basic team definition
 !unquoted procedure Team($label)
   rectangle "$label"
@@ -74,4 +85,14 @@ skinparam rectangle<<platform>> {
 ' Platform team with description
 !unquoted procedure Team_Platform($alias, $label, $descr)
   rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<platform>>
+!endprocedure
+
+' Enabling team
+!unquoted procedure Team_Enabling($alias, $label)
+  rectangle "$label" as $alias <<enabling>>
+!endprocedure
+
+' Enabling team with description
+!unquoted procedure Team_Enabling($alias, $label, $descr)
+  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<enabling>>
 !endprocedure

--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -19,7 +19,7 @@
 ' Team Type Colors
 !$STREAM_ALIGNED_COLOR = "#FAE1A0"
 !$PLATFORM_TEAM_COLOR = "#85B5D9"
-!$ENABLING_TEAM_COLOR = "#4CAF50"
+!$ENABLING_TEAM_COLOR = "#673AB7"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -54,9 +54,9 @@ skinparam rectangle<<platform>> {
 
 ' Define specific style for Enabling teams
 skinparam rectangle<<enabling>> {
-  BackgroundColor #4CAF50
-  BorderColor #368C3A
-  FontColor #333333
+  BackgroundColor #673AB7
+  BorderColor #5E35B1
+  FontColor #FFFFFF
   RoundCorner 20
   Shadowing false
   Padding 15

--- a/tests/test-enabling-team.puml
+++ b/tests/test-enabling-team.puml
@@ -1,0 +1,18 @@
+@startuml
+' Test diagram for TT-004: Enabling Team
+
+!include ../src/team-topologies.puml
+
+' Layout direction
+left to right direction
+
+' Test Enabling team - Basic version
+Team_Enabling(security_team, "Security Enablement")
+
+' Test Enabling team - With description
+Team_Enabling(devops_coaches, "DevOps Coaches", "Helps teams adopt DevOps practices and tools")
+
+' Add some spacing between the teams
+security_team -[hidden]-> devops_coaches
+
+@enduml


### PR DESCRIPTION
Implement Enabling team visual representation

This change adds the Enabling team type from Team Topologies to the PlantUML extension. The Enabling team is now properly represented with dark purple styling that matches the book's conventions.

Key improvements:
- Add Enabling team color definition (#673AB7, dark purple)
- Create two Team_Enabling macro variants:
  - Basic: alias and label only
  - Extended: includes description support
- Apply consistent styling with:
  - Dark purple background with darker border (#5E35B1)
  - White text for better readability on dark background
  - Rounded corners (20px)
  - Proper text formatting and padding

The implementation follows the same pattern established for Stream-aligned and Platform teams, maintaining consistency across team types.

Resolves: #TT-004