### PR TITLE
[TT-005] Implement Complicated-subsystem Team

### DIFF
--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -20,7 +20,7 @@
 !$STREAM_ALIGNED_COLOR = "#FAE1A0"
 !$PLATFORM_TEAM_COLOR = "#85B5D9"
 !$ENABLING_TEAM_COLOR = "#673AB7"
-!$COMPLICATED_SUBSYSTEM_COLOR = "#9C27B0"
+!$COMPLICATED_SUBSYSTEM_COLOR = "#4A148C"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -65,8 +65,8 @@ skinparam rectangle<<enabling>> {
 
 ' Define specific style for Complicated-subsystem teams
 skinparam rectangle<<complicated>> {
-  BackgroundColor #9C27B0
-  BorderColor #8E24AA
+  BackgroundColor #4A148C
+  BorderColor #3A1078
   FontColor #FFFFFF
   RoundCorner 20
   Shadowing false

--- a/src/team-topologies.puml
+++ b/src/team-topologies.puml
@@ -20,6 +20,7 @@
 !$STREAM_ALIGNED_COLOR = "#FAE1A0"
 !$PLATFORM_TEAM_COLOR = "#85B5D9"
 !$ENABLING_TEAM_COLOR = "#673AB7"
+!$COMPLICATED_SUBSYSTEM_COLOR = "#9C27B0"
 
 ' Basic skinparam settings
 skinparam defaultTextAlignment center
@@ -62,6 +63,16 @@ skinparam rectangle<<enabling>> {
   Padding 15
 }
 
+' Define specific style for Complicated-subsystem teams
+skinparam rectangle<<complicated>> {
+  BackgroundColor #9C27B0
+  BorderColor #8E24AA
+  FontColor #FFFFFF
+  RoundCorner 20
+  Shadowing false
+  Padding 15
+}
+
 ' Basic team definition
 !unquoted procedure Team($label)
   rectangle "$label"
@@ -95,4 +106,14 @@ skinparam rectangle<<enabling>> {
 ' Enabling team with description
 !unquoted procedure Team_Enabling($alias, $label, $descr)
   rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<enabling>>
+!endprocedure
+
+' Complicated-subsystem team
+!unquoted procedure Team_Complicated($alias, $label)
+  rectangle "$label" as $alias <<complicated>>
+!endprocedure
+
+' Complicated-subsystem team with description
+!unquoted procedure Team_Complicated($alias, $label, $descr)
+  rectangle "$label\n\n<size:12>[$descr]</size>" as $alias <<complicated>>
 !endprocedure

--- a/tests/test-complicated-subsystem-team.puml
+++ b/tests/test-complicated-subsystem-team.puml
@@ -1,0 +1,18 @@
+@startuml
+' Test diagram for TT-005: Complicated-subsystem Team
+
+!include ../src/team-topologies.puml
+
+' Layout direction
+left to right direction
+
+' Test Complicated-subsystem team - Basic version
+Team_Complicated(payment_engine, "Payment Processing Engine")
+
+' Test Complicated-subsystem team - With description
+Team_Complicated(risk_analysis, "Risk Analysis System", "Manages complex risk calculations and fraud detection algorithms")
+
+' Add some spacing between the teams
+payment_engine -[hidden]-> risk_analysis
+
+@enduml


### PR DESCRIPTION
Implement Complicated-subsystem team visual representation

This change adds the Complicated-subsystem team type from Team Topologies to the PlantUML extension. The Complicated-subsystem team is now properly represented with a dark purple styling that matches the Team Topologies book.

Key improvements:
- Add Complicated-subsystem team color definition (#4A148C, darker purple)
- Create two Team_Complicated macro variants:
  - Basic: alias and label only
  - Extended: includes description support
- Apply consistent styling with:
  - Dark purple background (#4A148C) with darker border (#3A1078)
  - White text for better readability on dark background
  - Rounded corners (20px)
  - Proper text formatting and padding

The implementation follows the same pattern established for the other team types, maintaining consistency across all team types. This completes the implementation of all four team types from Team Topologies.

Resolves: #TT-005